### PR TITLE
Have contract being migrated from notify registered contracts

### DIFF
--- a/.github/workflows/Integration.yml
+++ b/.github/workflows/Integration.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust: [1.67.1]
+        rust: [1.68.0]
         make:
           - name: Run integration tests # Integration tests
             task: "(cd tests && NODE_TYPE=LocalSecret ./gradlew jvmTest --build-cache --no-daemon)"
@@ -31,7 +31,7 @@ jobs:
       # Label used to access the service container
       secret:
         # Docker Hub image
-        image: ghcr.io/scrtlabs/localsecret:v1.6.1
+        image: ghcr.io/scrtlabs/localsecret:v1.8.0
         ports:
           # Opens tcp port
           - 5000:5000

--- a/contracts/snip721-dealer/Cargo.toml
+++ b/contracts/snip721-dealer/Cargo.toml
@@ -22,10 +22,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "8a6c1ca" }
-cosmwasm-contract-migratable-std = { git = "https://github.com/eqoty-labs/cosmwasm-contract-migratable-std", tag = "v0.5.0" }
+cosmwasm-contract-migratable-std = { git = "https://github.com/eqoty-labs/cosmwasm-contract-migratable-std", tag = "v1.0.0" }
 serde-cw-value = { version = "0.7.0" }
-serde = { version = "1.0.152", default-features = false, features = ["derive"] }
-schemars = "0.8.11"
+serde = { version = "1.0.154", default-features = false, features = ["derive"] }
+schemars = "0.8.12"
 cosmwasm-std = { git = "https://github.com/scrtlabs/cosmwasm", tag = "v1.1.9-secret" }
 cosmwasm-storage = { git = "https://github.com/scrtlabs/cosmwasm", tag = "v1.1.9-secret" }
 secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit", tag = "v0.8.0", default-features = false, features = ["crypto"] }

--- a/contracts/snip721-dealer/Cargo.toml
+++ b/contracts/snip721-dealer/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
+#backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "8a6c1ca" }

--- a/contracts/snip721-dealer/Cargo.toml
+++ b/contracts/snip721-dealer/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib", "rlib"]
 #backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "8a6c1ca" }
+snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "d42106f" }
 cosmwasm-contract-migratable-std = { git = "https://github.com/eqoty-labs/cosmwasm-contract-migratable-std", tag = "v1.0.0" }
 serde-cw-value = { version = "0.7.0" }
 serde = { version = "1.0.154", default-features = false, features = ["derive"] }

--- a/contracts/snip721-dealer/src/contract_migrate.rs
+++ b/contracts/snip721-dealer/src/contract_migrate.rs
@@ -139,14 +139,14 @@ pub(crate) fn migrate(
 
     let secret = Binary::from(rng.rand_bytes());
 
-    let migrated_to = Some(MigratedToState {
+    let migrated_to = MigratedToState {
         contract: ContractInfo {
             address: migrate_to_address,
             code_hash: migrate_to.code_hash,
         },
         migration_secret: secret.clone(),
-    });
-    save(deps.storage, MIGRATED_TO_KEY, &migrated_to.unwrap())?;
+    };
+    save(deps.storage, MIGRATED_TO_KEY, &migrated_to.clone())?;
     save(deps.storage, CONTRACT_MODE_KEY, &ContractMode::MigratedOut)?;
 
     let purchasable_metadata: PurchasableMetadata = load(deps.storage, PURCHASABLE_METADATA_KEY)?;
@@ -155,7 +155,8 @@ pub(crate) fn migrate(
     let contracts = load::<Vec<ContractInfo>>(deps.storage, NOTIFY_ON_MIGRATION_COMPLETE_KEY)?;
     let msg = to_binary(
         &MigrationListenerExecuteMsg::MigrationCompleteNotification {
-            from: env.contract.clone(),
+            to: migrated_to.contract,
+            data: None,
         },
     )?;
     let sub_msgs: Vec<SubMsg> = contracts

--- a/contracts/snip721-migratable/Cargo.toml
+++ b/contracts/snip721-migratable/Cargo.toml
@@ -22,10 +22,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "8a6c1ca" }
-cosmwasm-contract-migratable-std = { git = "https://github.com/eqoty-labs/cosmwasm-contract-migratable-std", tag = "v0.5.0" }
+cosmwasm-contract-migratable-std = { git = "https://github.com/eqoty-labs/cosmwasm-contract-migratable-std", tag = "v1.0.0" }
 serde-cw-value = { version = "0.7.0" }
-serde = { version = "1.0.152", default-features = false, features = ["derive"] }
-schemars = "0.8.11"
+serde = { version = "1.0.154", default-features = false, features = ["derive"] }
+schemars = "0.8.12"
 cosmwasm-std = { git = "https://github.com/scrtlabs/cosmwasm", tag = "v1.1.9-secret" }
 cosmwasm-storage = { git = "https://github.com/scrtlabs/cosmwasm", tag = "v1.1.9-secret" }
 secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit", tag = "v0.8.0", default-features = false, features = ["crypto"] }

--- a/contracts/snip721-migratable/Cargo.toml
+++ b/contracts/snip721-migratable/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
+#backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "8a6c1ca" }

--- a/contracts/snip721-migratable/Cargo.toml
+++ b/contracts/snip721-migratable/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib", "rlib"]
 #backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "8a6c1ca" }
+snip721-reference-impl = { git = "https://github.com/eqoty-labs/snip721-reference-impl", rev = "d42106f" }
 cosmwasm-contract-migratable-std = { git = "https://github.com/eqoty-labs/cosmwasm-contract-migratable-std", tag = "v1.0.0" }
 serde-cw-value = { version = "0.7.0" }
 serde = { version = "1.0.154", default-features = false, features = ["derive"] }

--- a/tests/gradle/libs.versions.toml
+++ b/tests/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ okio = "3.3.0"
 
 kermit = "1.2.2"
 
-secretk = "2.1.0"
+secretk = "2.3.0"
 
 bignum = "0.3.7"
 libsodium = "0.8.7"

--- a/tests/src/commonTest/kotlin/io/eqoty/dapp/secret/TestGlobals.kt
+++ b/tests/src/commonTest/kotlin/io/eqoty/dapp/secret/TestGlobals.kt
@@ -4,7 +4,6 @@ package io.eqoty.dapp.secret
 
 import co.touchlab.kermit.Logger
 import io.eqoty.cosmwasm.std.types.Coin
-import io.eqoty.cosmwasm.std.types.ContractInfo
 import io.eqoty.dapp.secret.utils.NodeInfo
 import io.eqoty.dapp.secret.utils.getNode
 import io.eqoty.secretk.client.SigningCosmWasmClient


### PR DESCRIPTION
Previously the contract being migrated to sent out the notification.  Instead have the contract being migrated from send the notifications.

This simplifies the implementation making queries to find migrated_to addresses unneeded in MigrationListenerExecuteMsg::MigrationCompleteNotification handlers